### PR TITLE
Enable arm kernel repositories

### DIFF
--- a/root/etc/e-smith/templates/etc/nethserver/eorepo.conf/01arm-kernels
+++ b/root/etc/e-smith/templates/etc/nethserver/eorepo.conf/01arm-kernels
@@ -1,0 +1,15 @@
+{
+   #
+   # 01arm_kernels
+   # Enable arm kernel repositories only on ARM-AltArch systems
+   #
+
+   if (( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) ||
+       ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64' )) {
+
+      push @repos, 'centos-kernel';
+
+   }
+   
+   '';
+}


### PR DESCRIPTION
Nethserver/arm-dev#40

This extends template expansion of `/etc/nethserver/eorepo.conf `found in nethserver-base.
The template is expanded by [software-repos-save](https://github.com/markVnl/nethserver-base/blob/250c34c790c8a51943ddefd413c378ce8bfa267b/createlinks#L281) event of nethserver-base, hence `event_templates` is ommitted in `createlinks` in this package

_Note:_ nethersver-subscription also adds template snippets for ` eorepo.conf `.