### PR TITLE
Disable default services

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -46,14 +46,14 @@ event_services('nethserver-arm-extra-config-update', qw(
 #--------------------------------------------------
 #
 
-#event_actions('system-init', qw(
-#              
-#));
+event_actions('system-init', qw(
+              arm-check-default-services 000
+));
 
-#event_templates('system-init',  qw(
-#
-#));
+event_templates('system-init',  qw(
 
-#event_services('system-init', qw( 
-#
-#));
+));
+
+event_services('system-init', qw( 
+
+));

--- a/root/etc/e-smith/events/actions/arm-check-default-services
+++ b/root/etc/e-smith/events/actions/arm-check-default-services
@@ -23,6 +23,6 @@
 for UNIT in NetworkManager NetworkManager-wait-online firewalld; do
     if systemctl is-active -q $UNIT; then
         systemctl stop $UNIT
-        systemctl preset $UNIT
     fi
+    systemctl mask $UNIT 
 done

--- a/root/etc/e-smith/events/actions/arm-check-default-services
+++ b/root/etc/e-smith/events/actions/arm-check-default-services
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (C) 2012 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Disable services from a default CentOS install
+for UNIT in NetworkManager NetworkManager-wait-online firewalld; do
+    if systemctl is-active -q $UNIT; then
+        systemctl stop $UNIT
+        systemctl preset $UNIT
+    fi
+done


### PR DESCRIPTION
/NethServer/arm-dev#35
/NethServer/arm-dev#46

Enable Networkmanager and Networkmanager-wait-online for the first boot. After all NM does a better job in finding a working network connection than all the mitigations we though of.

Disable NM (and other well-known unwanted services during systen-init, like we do @nethserver-install